### PR TITLE
Improving SSL (both KeyStore and TrustStore), enabling getting password from AWS Secrets, enabling configuration through DataStax Driver config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ https://github.com/wise-coders/cassandra-jdbc-driver
 * JDBC URL: jdbc:cassandra://host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[keyspace][?options]]
 * Website: [DbSchema](https://dbschema.com/cassandra-designer-tool.html)
 
+Make sure your password don't have any ampersand character (<code>&</code>), since it is part of the parameters' delimiter.
+If it is not possible, set your password by using a Properties object.
+
 The driver we wrote on top of the native [Cassandra Java Driver](https://github.com/datastax/java-driver)
+
+### Using a File to Configure Your Driver
+
+You can configure your driver using a file by passing using the `configfile` parameter and the path to file, like this:
+
+`configfile=/path/to/file.conf`
+
+Please, refer to [DataStax Driver Configuration Reference](https://docs.datastax.com/en/developer/java-driver/4.14/manual/core/configuration/reference/) to know all possible parameters.
 
 ## Connecting using SSL
 
@@ -51,6 +62,27 @@ If you're using client authentication:
 `-Djavax.net.ssl.keyStore=/path/to/client.keystore`
 
 `-Djavax.net.ssl.keyStorePassword=password123`
+
+## Retrieving your Password from an AWS Secrets Entry
+
+You can to retrieve your password from AWS Secrets by passing these parameters:
+
+* `awsregion`: The region which your secret was stored in;
+
+* `awssecretname`: The name of the secret were is your password stored in.
+
+* `awssecretkey`: The key of the secret used to get a password from your secret.
+
+To authenticate in AWS, the driver uses the DefaultCredentialsProviderChain. To know
+more about it, refer to [AWS DefaultCredentialsProvider documentation](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html).
+
+## Connecting to AWS Keyspaces
+
+You can connect to AWS Keyspaces by using this JDBC URI example:
+
+`jdbc:cassandra://<aws_keyspaces_endpoint>:9142/<default_keyspaces>?dc=<aws_region>&javax.net.ssl.trustStore=/path/to/client.truststore&javax.net.ssl.trustStorePassword=password123`
+
+Click here to know more about [AWS Keyspaces Service Endpoints](javax.net.ssl.trustStore=/path/to/client.truststore&javax.net.ssl.trustStorePassword=password123).
 
 ## How to Test the Driver
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,11 @@ repositories {
 }
 
 dependencies {
-    implementation "com.datastax.oss:java-driver-core:4.15.0"
+    implementation 'com.datastax.oss:java-driver-core:4.15.0'
+    implementation 'software.amazon.awssdk:secretsmanager:2.17.280'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-inline:4.8.0'
 }
 
 jar {

--- a/src/main/java/com/wisecoders/dbschema/cassandra/AWSUtil.java
+++ b/src/main/java/com/wisecoders/dbschema/cassandra/AWSUtil.java
@@ -1,0 +1,43 @@
+package com.wisecoders.dbschema.cassandra;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class AWSUtil {
+
+    public static String getSecretValue(String regionName, String secretName, String secretKey) {
+        Region region = Region.of(regionName);
+        SecretsManagerClient secretsClient = SecretsManagerClient.builder()
+                .region(region)
+                .build();
+        return getValue(secretsClient, secretName, secretKey);
+    }
+
+    public static String getValue(SecretsManagerClient secretsClient, String secretName, String secretKey) {
+        try {
+            GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
+                    .secretId(secretName)
+                    .build();
+            GetSecretValueResponse valueResponse = secretsClient.getSecretValue(valueRequest);
+            String secret = valueResponse.secretString();
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, String> map = mapper.readValue(secret, Map.class);
+            secretsClient.close();
+            return map.get(secretKey);
+        } catch (SecretsManagerException e) {
+            System.err.println(e.awsErrorDetails().errorMessage());
+            throw e;
+        } catch (JsonProcessingException e) {
+            System.err.println(e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/wisecoders/dbschema/cassandra/CassandraClientURITest.java
+++ b/src/test/java/com/wisecoders/dbschema/cassandra/CassandraClientURITest.java
@@ -1,6 +1,9 @@
 package com.wisecoders.dbschema.cassandra;
 
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -84,5 +87,31 @@ public class CassandraClientURITest {
                 "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra",
                 properties);
         assertFalse(uri.getSslEnabled());
+    }
+
+    @Test
+    public void testAwsSecretNotFound() {
+        SecretsManagerException sme = (SecretsManagerException) SecretsManagerException
+                .builder()
+                .message("Any error")
+                .build();
+
+        String region = "sa-east-1";
+        String secretName = "a_secret_name";
+        String secretKey = "a_secret_key";
+
+        try (MockedStatic<AWSUtil> utilities = Mockito.mockStatic(AWSUtil.class)) {
+            utilities.when(() -> AWSUtil.getSecretValue(region, secretName, secretKey)).thenThrow(sme);
+
+            try {
+                CassandraClientURI uri = new CassandraClientURI(
+                        "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra&awsregion=sa-east-1&awssecretname=a_secret_name&awssecretkey=a_secret_key&anyFieldEndingWithPassword=another_pass",
+                        new Properties());
+            } catch (Exception e) {
+                assertTrue(e instanceof SecretsManagerException);
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
- Improving SSL (both KeyStore and TrustStore)
- Enabling getting password from AWS Secrets (DefaultCredentialsAuthenticationChain)
- Enabling configuration through DataStax Driver config file
- Sanitizing URI logging, hiding passwords to avoid a possible password leak